### PR TITLE
Altered query and added metaquery for published posts

### DIFF
--- a/seo-research.php
+++ b/seo-research.php
@@ -93,7 +93,7 @@ class Yoast_Research {
 		$args = array(
 			'post_type'      => WPSEO_Post_Type::get_accessible_post_types(),
 			'orderby'        => 'rand',
-			'posts_per_page' => 100,
+			'posts_per_page' => 10,
 			'post_status' => array( 'publish' ),
 			'has_password' => false,
 

--- a/seo-research.php
+++ b/seo-research.php
@@ -93,7 +93,17 @@ class Yoast_Research {
 		$args = array(
 			'post_type'      => WPSEO_Post_Type::get_accessible_post_types(),
 			'orderby'        => 'rand',
-			'posts_per_page' => 10,
+			'posts_per_page' => 100,
+			'post_status' => array( 'publish' ),
+			'has_password' => false,
+
+			'meta_query' => array(
+				array(
+					'key'     => WPSEO_Meta::$meta_prefix . 'focuskw',
+					'value'   => '',
+					'compare' => '!=',
+				),
+			),
 		);
 
 		remove_action( 'wp_head', 'wpseo_head' );


### PR DESCRIPTION
This query will ensure that only posts that are published and don't have a password attached to them, don't get taken into account. Additionally it filters out posts and terms that have no keyword, as they are useless.